### PR TITLE
Add video gallery support

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -76,6 +76,27 @@ body {
   box-shadow: 0 6px 16px rgba(0, 0, 0, .25);
 }
 
+/* --- Media Tabs --- */
+.tab-container {
+  display: flex;
+  margin-top: 20px;
+  justify-content: center;
+}
+.tab {
+  padding: 8px 16px;
+  border: 1px solid #ccc;
+  border-bottom: none;
+  background: #e0e0e0;
+  cursor: pointer;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  margin: 0 2px;
+}
+.tab.active {
+  background: #fff;
+  z-index: 1;
+}
+
 
 /* --- Gallery --- */
 .gallery {
@@ -95,8 +116,18 @@ body {
   transition: transform .3s ease;
   cursor: pointer;
 }
+.gallery video {
+  width: 100%;
+  height: 300px;
+  object-fit: cover;
+  border-radius: 16px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, .2);
+  transition: transform .3s ease;
+  cursor: pointer;
+}
 
 .gallery img:hover { transform: scale(1.05); }
+.gallery video:hover { transform: scale(1.05); }
 
 /* --- Floating Hearts --- */
 .heart {
@@ -182,6 +213,12 @@ footer {
   pointer-events: auto;
 }
 .lightbox img {
+  max-width: 90%;
+  max-height: 90%;
+  border-radius: 12px;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.6);
+}
+.lightbox video {
   max-width: 90%;
   max-height: 90%;
   border-radius: 12px;

--- a/index.html
+++ b/index.html
@@ -26,19 +26,26 @@
     <button id="playBtn"           class="btn">פלייליסט 🎵</button>
     <button id="letterBtn"         class="btn">מכתב 💌</button>
     <button id="shuffleGalleryBtn" class="btn">גלריה 🖼️</button>
-    <button id="uploadImgBtn"      class="btn">העלה תמונות 📸</button>
+    <button id="uploadImgBtn"      class="btn">העלה מדיה</button>
     <button id="uploadSongBtn"     class="btn">העלה שירים 🎶</button>
+  </div>
+
+  <div class="tab-container">
+    <button id="videosTab" class="tab">סרטונים</button>
+    <button id="imagesTab" class="tab active">תמונות</button>
   </div>
 
   <!-- 🖼️ Image gallery -->
   <main>
     <div id="gallery" class="gallery"></div>
+    <div id="videoGallery" class="gallery" style="display:none"></div>
   </main>
 
   <!-- 🔍 Image lightbox -->
   <div id="lightbox" class="lightbox">
     <button class="close-btn" onclick="hideLightbox()">❌</button>
     <img id="lightbox-img" src="" alt="תמונה" />
+    <video id="lightbox-video" controls style="display:none"></video>
   </div>
 
   <!-- 💌 Love‑letter popup -->


### PR DESCRIPTION
## Summary
- rename upload button to indicate media uploads
- add gallery tabs for images and videos
- support video listing and uploads in JS
- extend lightbox to handle video playback
- style new media tabs and video elements

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685a67284a4c83258683c02301926d26